### PR TITLE
fix error when switching to main

### DIFF
--- a/package/debian.rules
+++ b/package/debian.rules
@@ -3,5 +3,9 @@
 override_dh_auto_configure:
 	dh_auto_configure -- -DENABLE_PROTO_SHELL=OFF
 
+override_dh_install:
+	dh_install
+	dh_installdirs /lib/netifd
+
 %:
 	dh $@ --buildsystem=cmake


### PR DESCRIPTION
At the moment main dir is not used in netifd, because scripts are disabled and there are no external devices configured. Because of that the main path (/lib/netifd) does not exist at all and chdir(main path): No such file or directory
is printed on startup.