### PR TITLE
udhcp/zcip: fix udhcp/zcip not starting

### DIFF
--- a/proto-udhcp.c
+++ b/proto-udhcp.c
@@ -54,7 +54,9 @@ static void
 dhcp_process_callback(struct netifd_process *proc, int ret)
 {
 	struct dhcp_proto_state *state = container_of(proc, struct dhcp_proto_state, client);
-	if (!state->teardown) { /* unexpected shutdown, restart */
+	if (state->teardown) {
+		state->proto.proto_event(&state->proto, IFPEV_DOWN);
+	} else { /* unexpected shutdown, restart */
 		int code = -1;
 		char *desc = "unknown";
 		if (WIFEXITED(ret)) {
@@ -130,6 +132,8 @@ udhcp_handler(struct interface_proto_state *proto,
 		if (state->client.uloop.pending) {
 			state->teardown = true;
 			kill(state->client.uloop.pid, SIGTERM);
+		} else {
+			state->proto.proto_event(&state->proto, IFPEV_DOWN);
 		}
 		break;
 	case PROTO_CMD_RENEW:
@@ -171,11 +175,7 @@ udhcp4_configure(struct dhcp_proto_state *state, const char *action, struct blob
 	if (strcmp(action, "deconfig") == 0) {
 		interface_update_start(iface, false);
 		interface_update_complete(iface);
-		if (state->teardown) {
-			state->proto.proto_event(&state->proto, IFPEV_DOWN);
-		} else {
-			state->proto.proto_event(&state->proto, IFPEV_LINK_LOST);
-		}
+		state->proto.proto_event(&state->proto, IFPEV_LINK_LOST);
 	} else if (strcmp(action, "bound") == 0 || strcmp(action, "renew") == 0) {
 		interface_update_start(iface, false);
 

--- a/proto-zcip.c
+++ b/proto-zcip.c
@@ -41,7 +41,9 @@ static void
 zcip_process_callback(struct netifd_process *proc, int ret)
 {
 	struct zcip_proto_state *state = container_of(proc, struct zcip_proto_state, client);
-	if (!state->teardown) { /* unexpected shutdown, restart */
+	if (state->teardown) {
+		state->proto.proto_event(&state->proto, IFPEV_DOWN);
+	} else { /* unexpected shutdown, restart */
 		int code = -1;
 		char *desc = "unknown";
 		if (WIFEXITED(ret)) {
@@ -109,6 +111,8 @@ zcip_handler(struct interface_proto_state *proto,
 		if (state->client.uloop.pending) {
 			state->teardown = true;
 			kill(state->client.uloop.pid, SIGTERM);
+		} else {
+			state->proto.proto_event(&state->proto, IFPEV_DOWN);
 		}
 		break;
 	case PROTO_CMD_RENEW:
@@ -127,11 +131,7 @@ zcip_configure(struct zcip_proto_state *state, const char *action, struct blob_a
 	} else if (strcmp(action, "deconfig") == 0) {
 		interface_update_start(iface, false);
 		interface_update_complete(iface);
-		if (state->teardown) {
-			state->proto.proto_event(&state->proto, IFPEV_DOWN);
-		} else {
-			state->proto.proto_event(&state->proto, IFPEV_LINK_LOST);
-		}
+		state->proto.proto_event(&state->proto, IFPEV_LINK_LOST);
 	} else if (strcmp(action, "config") == 0) {
 		interface_update_start(iface, false);
 


### PR DESCRIPTION
When netifd brings the interface down,
because there is no port up anymore the protocol
must send the IFPEV_DOWN event in order to receive the PROTO_CMD_SETUP event again.

For dhcp and zcip the IFPEV_DOWN event was sent
by the protocol after the process received the terminate signal and send a message back to the protocol using the notify mechanism.

When the terminate signal is send to the process before the signal handlers are setup, no notify message is send to notify message is send and no IFPEV_DOWN is generated.

Now the IFPEV_DOWN is always send, when the process terminates (in teardown state) or when the process is not yet created.