### PR TITLE
Fix Python Test (broke due to iproute2 non-backward compatible version update)

### DIFF
--- a/test/test_runner/process.py
+++ b/test/test_runner/process.py
@@ -20,7 +20,7 @@ def start_process(cmd: List[str], netns: NetNS = None, log: str = None) -> subpr
     if not netns:
         process = subprocess.Popen(**args)
     else:
-        process = NSPopen(netns.netns, **args)
+        process = NSPopen(netns.status["netns"], **args)
     if fd != -1:
         os.close(fd)
     return process
@@ -48,7 +48,7 @@ def run_process(cmd: List[str], netns: NetNS = None, stdout: str = None, stderr:
         args["stderr"] = stderr
 
     proc = NSPopen(
-        netns.netns,
+        netns.status["netns"],
         **args
     )
     out = proc.communicate()

--- a/test/test_runner/runner.py
+++ b/test/test_runner/runner.py
@@ -62,7 +62,7 @@ class TestSuiteRun():
             kind='veth',
             peer={
                 "ifname": peername,
-                "net_ns_fd": self._netns_test.netns
+                "net_ns_fd": self._netns_test.status["netns"]
             }
         )
         idx = self._ipr.link_lookup(ifname=name)[0]
@@ -120,7 +120,7 @@ class TestSuiteRun():
                 "ip",
                 "netns",
                 "exec",
-                self._netns_test.netns,
+                self._netns_test.status["netns"],
                 NETIFD_PATH,
                 "-c", os.path.dirname(self._suite.network_config),
                 "-r", self._get_temp_file("resolv.conf"),


### PR DESCRIPTION
Netns Class is now a wrapper of IPRoute
netns functionality is moved to libcore.
the Netns name comes available like this:

```
from pyroute2 import NetNS
        with NetNS("test") as ns:
            assert ns.status["netns"] == "test"
```