### PR TITLE
update netifd

### DIFF
--- a/bonding.c
+++ b/bonding.c
@@ -468,10 +468,8 @@ bonding_reload(struct device *dev, struct blob_attr *attr)
 	bdev = container_of(dev, struct bonding_device, dev);
 	attr = blob_memdup(attr);
 
-	blobmsg_parse(device_attr_list.params, __DEV_ATTR_MAX, tb_dev,
-		blob_data(attr), blob_len(attr));
-	blobmsg_parse(bonding_attrs, __BOND_ATTR_MAX, tb_b,
-		blob_data(attr), blob_len(attr));
+	blobmsg_parse_attr(device_attr_list.params, __DEV_ATTR_MAX, tb_dev, attr);
+	blobmsg_parse_attr(bonding_attrs, __BOND_ATTR_MAX, tb_b, attr);
 
 	bdev->has_macaddr = tb_dev[DEV_ATTR_MACADDR];
 	if (bdev->primary_port && !bdev->primary_port->set_primary &&
@@ -486,15 +484,15 @@ bonding_reload(struct device *dev, struct blob_attr *attr)
 		struct blob_attr *otb_dev[__DEV_ATTR_MAX];
 		struct blob_attr *otb_b[__BOND_ATTR_MAX];
 
-		blobmsg_parse(device_attr_list.params, __DEV_ATTR_MAX, otb_dev,
-			blob_data(bdev->config_data), blob_len(bdev->config_data));
+		blobmsg_parse_attr(device_attr_list.params, __DEV_ATTR_MAX, otb_dev,
+				   bdev->config_data);
 
 		uci_blob_diff(tb_dev, otb_dev, &device_attr_list, diff);
 		if (diff[0] | diff[1])
 		    ret = DEV_CONFIG_RESTART;
 
-		blobmsg_parse(bonding_attrs, __BOND_ATTR_MAX, otb_b,
-			blob_data(bdev->config_data), blob_len(bdev->config_data));
+		blobmsg_parse_attr(bonding_attrs, __BOND_ATTR_MAX, otb_b,
+				   bdev->config_data);
 
 		diff[0] = 0;
 		uci_blob_diff(tb_b, otb_b, &bonding_attr_list, diff);

--- a/bridge.c
+++ b/bridge.c
@@ -938,7 +938,16 @@ bridge_member_update(struct vlist_tree *tree, struct vlist_node *node_new,
 		bm = container_of(node_new, struct bridge_member, node);
 
 		if (node_old) {
+			struct device *dev = bm->dev.dev;
+
 			free(bm);
+
+			bm = container_of(node_old, struct bridge_member, node);
+			if (!dev || dev == bm->dev.dev)
+				return;
+
+			bridge_remove_member(bm);
+			device_add_user(&bm->dev, dev);
 			return;
 		}
 
@@ -1268,10 +1277,8 @@ bridge_reload(struct device *dev, struct blob_attr *attr)
 	bst = container_of(dev, struct bridge_state, dev);
 	attr = blob_memdup(attr);
 
-	blobmsg_parse(device_attr_list.params, __DEV_ATTR_MAX, tb_dev,
-		blob_data(attr), blob_len(attr));
-	blobmsg_parse(bridge_attrs, __BRIDGE_ATTR_MAX, tb_br,
-		blob_data(attr), blob_len(attr));
+	blobmsg_parse_attr(device_attr_list.params, __DEV_ATTR_MAX, tb_dev, attr);
+	blobmsg_parse_attr(bridge_attrs, __BRIDGE_ATTR_MAX, tb_br, attr);
 
 	if (tb_dev[DEV_ATTR_MACADDR])
 		bst->primary_port = NULL;
@@ -1284,8 +1291,8 @@ bridge_reload(struct device *dev, struct blob_attr *attr)
 		struct blob_attr *otb_dev[__DEV_ATTR_MAX];
 		struct blob_attr *otb_br[__BRIDGE_ATTR_MAX];
 
-		blobmsg_parse(device_attr_list.params, __DEV_ATTR_MAX, otb_dev,
-			blob_data(bst->config_data), blob_len(bst->config_data));
+		blobmsg_parse_attr(device_attr_list.params, __DEV_ATTR_MAX, otb_dev,
+				   bst->config_data);
 
 		uci_blob_diff(tb_dev, otb_dev, &device_attr_list, diff);
 		if (diff[0] | diff[1]) {
@@ -1294,8 +1301,7 @@ bridge_reload(struct device *dev, struct blob_attr *attr)
 			  dev->ifname, diff[1], diff[0]);
 		}
 
-		blobmsg_parse(bridge_attrs, __BRIDGE_ATTR_MAX, otb_br,
-			blob_data(bst->config_data), blob_len(bst->config_data));
+		blobmsg_parse_attr(bridge_attrs, __BRIDGE_ATTR_MAX, otb_br, bst->config_data);
 
 		diff[0] = diff[1] = 0;
 		uci_blob_diff(tb_br, otb_br, &bridge_attr_list, diff);
@@ -1305,7 +1311,7 @@ bridge_reload(struct device *dev, struct blob_attr *attr)
 			  dev->ifname, diff[1], diff[0]);
 		}
 
-		bridge_config_init(dev);
+		dev->config_pending = true;
 	}
 
 	free(bst->config_data);
@@ -1345,7 +1351,7 @@ bridge_vlan_equal(struct bridge_vlan *v1, struct bridge_vlan *v2)
 {
 	int i;
 
-	if (v1->n_ports != v2->n_ports)
+	if (v1->n_ports != v2->n_ports || v1->local != v2->local)
 		return false;
 
 	for (i = 0; i < v1->n_ports; i++)

--- a/config.c
+++ b/config.c
@@ -37,26 +37,24 @@ static struct uci_context *uci_ctx;
 static struct uci_package *uci_network;
 static struct blob_attr *board_netdevs;
 static struct blob_buf b;
+static LIST_HEAD(config_vlans);
+static LIST_HEAD(config_ifaces);
+
+struct vlan_config_entry {
+	struct list_head list;
+	struct blob_attr *data;
+	char *dev_name;
+	char name[];
+};
 
 static bool
 config_bridge_has_vlans(const char *br_name)
 {
-	struct uci_element *e;
+	struct vlan_config_entry *e;
 
-	uci_foreach_element(&uci_network->sections, e) {
-		struct uci_section *s = uci_to_section(e);
-		const char *name;
-
-		if (strcmp(s->type, "bridge-vlan") != 0)
-			continue;
-
-		name = uci_lookup_option_string(uci_ctx, s, "device");
-		if (!name)
-			continue;
-
-		if (!strcmp(name, br_name))
+	list_for_each_entry(e, &config_vlans, list)
+		if (!strcmp(e->dev_name, br_name))
 			return true;
-	}
 
 	return false;
 }
@@ -194,7 +192,7 @@ config_parse_interface(struct uci_section *s, bool alias)
 error_free_config:
 	free(config);
 error:
-	free(iface);
+	interface_free(iface);
 }
 
 static void
@@ -233,6 +231,123 @@ config_parse_rule(struct uci_section *s, bool v6)
 }
 
 static void
+config_insert_vlan_entry(const char *name, const char *dev_name, struct blob_attr *data)
+{
+	struct vlan_config_entry *e, *tmp;
+	struct blob_attr *attrbuf;
+	char *dev_name_buf;
+
+	list_for_each_entry_safe(e, tmp, &config_vlans, list) {
+		if (strcmp(e->name, name) != 0)
+			continue;
+
+		list_del(&e->list);
+		free(e);
+	}
+
+	e = calloc_a(sizeof(*e) + strlen(name) + 1,
+		     &attrbuf, blob_pad_len(data),
+		     &dev_name_buf, strlen(dev_name) + 1);
+	e->data = memcpy(attrbuf, data, blob_pad_len(data));
+	e->dev_name = strcpy(dev_name_buf, dev_name);
+	strcpy(e->name, name);
+	list_add_tail(&e->list, &config_vlans);
+}
+
+static void
+config_device_add(const char *name, struct device_type *devtype,
+		  struct blob_attr *config)
+{
+	struct device *dev;
+
+	if (devtype) {
+		dev = device_create(name, devtype, config);
+	} else {
+		dev = device_get(name, 1);
+		if (!dev)
+			return;
+
+		dev->current_config = true;
+		device_apply_config(dev, dev->type, config);
+	}
+
+	dev->default_config = false;
+}
+
+static void
+config_procd_device_cb(struct blob_attr *data)
+{
+	static const struct blobmsg_policy policy =
+		{ "type", BLOBMSG_TYPE_STRING };
+	const char *name = blobmsg_name(data);
+	struct device_type *devtype = NULL;
+	struct blob_attr *attr;
+
+	blobmsg_parse_attr(&policy, 1, &attr, data);
+	if (attr) {
+		const char *type_name = blobmsg_get_string(attr);
+
+		if (!strcmp(type_name, "bridge"))
+			return;
+
+		devtype = device_type_get(type_name);
+		if (!devtype)
+			return;
+	}
+
+	config_device_add(name, devtype, data);
+}
+
+static void
+config_procd_bridge_cb(struct blob_attr *data)
+{
+	enum {
+		PROCD_DEV_ATTR_TYPE,
+		PROCD_DEV_ATTR_VLANS,
+		__PROCD_DEV_ATTR_MAX
+	};
+	static const struct blobmsg_policy policy[] = {
+		[PROCD_DEV_ATTR_TYPE] = { "type", BLOBMSG_TYPE_STRING },
+		[PROCD_DEV_ATTR_VLANS] = { "vlans", BLOBMSG_TYPE_TABLE },
+	};
+	const char *name = blobmsg_name(data);
+	struct blob_attr *tb[__PROCD_DEV_ATTR_MAX], *attr, *cur;
+	struct device_type *devtype;
+	struct device *dev;
+	int len = 0;
+	size_t rem;
+
+	blobmsg_parse_attr(policy, ARRAY_SIZE(policy), tb, data);
+	if (!tb[PROCD_DEV_ATTR_TYPE] ||
+	    strcmp(blobmsg_get_string(tb[PROCD_DEV_ATTR_TYPE]), "bridge") != 0)
+		return;
+
+	devtype = device_type_get("bridge");
+	if (!devtype)
+		return;
+
+	attr = tb[PROCD_DEV_ATTR_VLANS];
+	if (attr)
+		len = blobmsg_check_array(attr, BLOBMSG_TYPE_TABLE);
+	if (len < 0)
+		return;
+
+	if (len > 0 || config_bridge_has_vlans(name)) {
+		blob_buf_init(&b, 0);
+		blob_put_raw(&b, blobmsg_data(data), blobmsg_len(data));
+		blobmsg_add_u8(&b, "vlan_filtering", 1);
+		data = b.head;
+	}
+
+	dev = device_create(name, devtype, data);
+	if (!dev || !dev->vlans.update || !len)
+		return;
+
+	blobmsg_for_each_attr(cur, attr, rem)
+		config_insert_vlan_entry(blobmsg_name(cur), name, cur);
+}
+
+static void
 config_init_devices(bool bridge)
 {
 	struct uci_element *e;
@@ -241,7 +356,6 @@ config_init_devices(bool bridge)
 		const struct uci_blob_param_list *params = NULL;
 		struct uci_section *s = uci_to_section(e);
 		struct device_type *devtype = NULL;
-		struct device *dev;
 		const char *type, *name;
 
 		if (strcmp(s->type, "device") != 0)
@@ -270,65 +384,47 @@ config_init_devices(bool bridge)
 
 		blob_buf_init(&b, 0);
 		uci_to_blob(&b, s, params);
-		if (devtype) {
-			dev = device_create(name, devtype, b.head);
-			if (!dev)
-				continue;
-		} else {
-			dev = device_get(name, 1);
-			if (!dev)
-				continue;
-
-			dev->current_config = true;
-			device_apply_config(dev, dev->type, b.head);
-		}
-		dev->default_config = false;
+		config_device_add(name, devtype, b.head);
 	}
+
+	netifd_ubus_get_procd_data("network-device",
+		bridge ? config_procd_bridge_cb : config_procd_device_cb);
 }
 
+enum {
+	BRVLAN_ATTR_VID,
+	BRVLAN_ATTR_LOCAL,
+	BRVLAN_ATTR_PORTS,
+	BRVLAN_ATTR_ALIAS,
+	__BRVLAN_ATTR_MAX,
+};
+
+static const struct blobmsg_policy vlan_attrs[__BRVLAN_ATTR_MAX] = {
+	[BRVLAN_ATTR_VID] = { "vlan", BLOBMSG_TYPE_INT32 },
+	[BRVLAN_ATTR_LOCAL] = { "local", BLOBMSG_TYPE_BOOL },
+	[BRVLAN_ATTR_PORTS] = { "ports", BLOBMSG_TYPE_ARRAY },
+	[BRVLAN_ATTR_ALIAS] = { "alias", BLOBMSG_TYPE_ARRAY },
+};
+
 static void
-config_parse_vlan(struct device *dev, struct uci_section *s)
+config_init_vlan_entry(struct vlan_config_entry *e)
 {
-	enum {
-		BRVLAN_ATTR_VID,
-		BRVLAN_ATTR_LOCAL,
-		BRVLAN_ATTR_PORTS,
-		BRVLAN_ATTR_ALIAS,
-		__BRVLAN_ATTR_MAX,
-	};
-	static const struct blobmsg_policy vlan_attrs[__BRVLAN_ATTR_MAX] = {
-		[BRVLAN_ATTR_VID] = { "vlan", BLOBMSG_TYPE_INT32 },
-		[BRVLAN_ATTR_LOCAL] = { "local", BLOBMSG_TYPE_BOOL },
-		[BRVLAN_ATTR_PORTS] = { "ports", BLOBMSG_TYPE_ARRAY },
-		[BRVLAN_ATTR_ALIAS] = { "alias", BLOBMSG_TYPE_ARRAY },
-	};
-	static const struct uci_blob_param_info vlan_attr_info[__BRVLAN_ATTR_MAX] = {
-		[BRVLAN_ATTR_PORTS] = { .type = BLOBMSG_TYPE_STRING },
-		[BRVLAN_ATTR_ALIAS] = { .type = BLOBMSG_TYPE_STRING },
-	};
-	static const struct uci_blob_param_list vlan_attr_list = {
-		.n_params = __BRVLAN_ATTR_MAX,
-		.params = vlan_attrs,
-		.info = vlan_attr_info,
-	};
 	struct blob_attr *tb[__BRVLAN_ATTR_MAX];
 	struct blob_attr *cur;
 	struct bridge_vlan_port *port;
 	struct bridge_vlan *vlan;
+	struct device *dev;
 	unsigned int vid;
-	const char *val;
 	char *name_buf;
 	int name_len = 0;
 	int n_ports = 0;
 	size_t rem;
 
-	val = uci_lookup_option_string(uci_ctx, s, "vlan");
-	if (!val)
+	dev = device_get(e->dev_name, 0);
+	if (!dev || !dev->vlans.update)
 		return;
 
-	blob_buf_init(&b, 0);
-	uci_to_blob(&b, s, &vlan_attr_list);
-	blobmsg_parse(vlan_attrs, __BRVLAN_ATTR_MAX, tb, blob_data(b.head), blob_len(b.head));
+	blobmsg_parse_attr(vlan_attrs, __BRVLAN_ATTR_MAX, tb, e->data);
 
 	if (!tb[BRVLAN_ATTR_VID])
 		return;
@@ -386,14 +482,43 @@ config_parse_vlan(struct device *dev, struct uci_section *s)
 	vlist_add(&dev->vlans, &vlan->node, &vlan->vid);
 }
 
+static void
+config_load_vlan(const char *dev_name, struct uci_section *s)
+{
+	static const struct uci_blob_param_info vlan_attr_info[__BRVLAN_ATTR_MAX] = {
+		[BRVLAN_ATTR_PORTS] = { .type = BLOBMSG_TYPE_STRING },
+		[BRVLAN_ATTR_ALIAS] = { .type = BLOBMSG_TYPE_STRING },
+	};
+	static const struct uci_blob_param_list vlan_attr_list = {
+		.n_params = __BRVLAN_ATTR_MAX,
+		.params = vlan_attrs,
+		.info = vlan_attr_info,
+	};
+
+	blob_buf_init(&b, 0);
+	uci_to_blob(&b, s, &vlan_attr_list);
+	config_insert_vlan_entry(s->e.name, dev_name, b.head);
+}
 
 static void
-config_init_vlans(void)
+config_procd_vlan_cb(struct blob_attr *data)
+{
+	static const struct blobmsg_policy policy =
+		{ "device", BLOBMSG_TYPE_STRING };
+	struct blob_attr *attr;
+
+	blobmsg_parse_attr(&policy, 1, &attr, data);
+	if (!attr)
+		return;
+
+	config_insert_vlan_entry(blobmsg_name(data), blobmsg_get_string(attr), data);
+}
+
+static void
+config_load_vlans(void)
 {
 	struct uci_element *e;
-	struct device *dev;
 
-	device_vlan_update(false);
 	uci_foreach_element(&uci_network->sections, e) {
 		struct uci_section *s = uci_to_section(e);
 		const char *name;
@@ -405,11 +530,23 @@ config_init_vlans(void)
 		if (!name)
 			continue;
 
-		dev = device_get(name, 0);
-		if (!dev || !dev->vlans.update)
-			continue;
+		config_load_vlan(name, s);
+	}
 
-		config_parse_vlan(dev, s);
+	netifd_ubus_get_procd_data("bridge-vlan", config_procd_vlan_cb);
+}
+
+static void
+config_init_vlans(void)
+{
+	struct vlan_config_entry *e;
+
+	device_vlan_update(false);
+	while (!list_empty(&config_vlans)) {
+		e = list_first_entry(&config_vlans, struct vlan_config_entry, list);
+		list_del(&e->list);
+		config_init_vlan_entry(e);
+		free(e);
 	}
 	device_vlan_update(true);
 }
@@ -444,8 +581,29 @@ config_init_package(const char *config)
 }
 
 static void
+config_procd_interface_cb(struct blob_attr *data)
+{
+	struct interface *iface;
+	const char *name = blobmsg_name(data);
+
+	iface = interface_alloc(name, data, false);
+	if (!iface)
+		return;
+
+	data = blob_memdup(data);
+	if (!data) {
+		interface_free(iface);
+		return;
+	}
+
+	iface->config = data;
+	list_add(&iface->node.avl.list, &config_ifaces);
+}
+
+static void
 config_init_interfaces(void)
 {
+	struct interface *iface;
 	struct uci_element *e;
 
 	uci_foreach_element(&uci_network->sections, e) {
@@ -460,6 +618,15 @@ config_init_interfaces(void)
 
 		if (!strcmp(s->type, "alias"))
 			config_parse_interface(s, true);
+	}
+
+	netifd_ubus_get_procd_data("network-interface", config_procd_interface_cb);
+	while (!list_empty(&config_ifaces)) {
+		iface = list_first_entry(&config_ifaces, struct interface, node.avl.list);
+		list_del(&iface->node.avl.list);
+
+		if (!interface_add(iface, iface->config))
+			interface_free(iface);
 	}
 }
 
@@ -549,7 +716,7 @@ config_find_blobmsg_attr(struct blob_attr *attr, const char *name, int type)
 	struct blobmsg_policy policy = { .name = name, .type = type };
 	struct blob_attr *cur;
 
-	blobmsg_parse(&policy, 1, &cur, blobmsg_data(attr), blobmsg_len(attr));
+	blobmsg_parse_attr(&policy, 1, &cur, attr);
 
 	return cur;
 }
@@ -649,6 +816,7 @@ config_init_all(void)
 	config_init = true;
 
 	device_reset_config();
+	config_load_vlans();
 	config_init_devices(true);
 	config_init_vlans();
 	config_init_devices(false);

--- a/device.c
+++ b/device.c
@@ -226,7 +226,7 @@ simple_device_create(const char *name, struct device_type *devtype,
 	/* device type is unused for simple devices */
 	devtype = NULL;
 
-	blobmsg_parse(dev_attrs, __DEV_ATTR_MAX, tb, blob_data(attr), blob_len(attr));
+	blobmsg_parse_attr(dev_attrs, __DEV_ATTR_MAX, tb, attr);
 	dev = device_get(name, true);
 	if (!dev)
 		return NULL;
@@ -1233,8 +1233,7 @@ device_set_config(struct device *dev, struct device_type *type,
 		memset(tb, 0, sizeof(tb));
 
 		if (attr)
-			blobmsg_parse(dev_attrs, __DEV_ATTR_MAX, tb,
-				blob_data(attr), blob_len(attr));
+			blobmsg_parse_attr(dev_attrs, __DEV_ATTR_MAX, tb, attr);
 
 		device_init_settings(dev, tb);
 		return DEV_CONFIG_RESTART;

--- a/examples/wireless-device.uc
+++ b/examples/wireless-device.uc
@@ -36,6 +36,8 @@ function handle_link(dev, data, up)
 		     (data.type == "vif" && config.mode == "ap");
 
 	let dev_data = {
+		external: 2,
+		check_vlan: false,
 		isolate: !!config.bridge_isolate,
 		wireless: true,
 		wireless_ap: ap,
@@ -389,11 +391,14 @@ function update(data)
 
 function start()
 {
-	if (this.delete || this.data.config.disabled)
+	if (this.delete)
 		return;
 
 	this.dbg("start, state=" + this.state);
 	this.autostart = true;
+	if (this.data.config.disabled)
+		return;
+
 	wdev_reset(this);
 
 	if (this.state != "down")
@@ -425,7 +430,10 @@ function check()
 		return;
 
 	wdev_config_init(this);
-	this.setup();
+	if (this.data.config.disabled)
+		this.teardown();
+	else
+		this.setup();
 }
 
 function wdev_mark_up(wdev)
@@ -530,7 +538,7 @@ function hotplug(name, add)
 		    data.type != "vif" && data.type != "vlan")
 			continue;
 
-		handle_link(dev, data, up);
+		handle_link(dev, data, add);
 	}
 }
 

--- a/examples/wireless.uc
+++ b/examples/wireless.uc
@@ -186,37 +186,79 @@ function config_init(uci)
 		object: "service",
 		method: "get_data",
 		data: {
+			type: "wifi-device"
+		},
+	});
+	for (let svcname, svc in udata) {
+		for (let insname, ins in svc) {
+			for (let typename, data in ins) {
+				for (let radio, config in data) {
+					if (type(config) != "object")
+						continue;
+
+					let dev = devices[radio];
+					if (dev) {
+						dev.config = { ...dev.config, ...config };
+						continue;
+					}
+
+					let handler = wireless.handlers[config.type];
+					if (!handler)
+						continue;
+
+					dev = devices[radio] = {
+						name,
+						config,
+
+						vif: [],
+					};
+					handlers[radio] = handler;
+				}
+			}
+		}
+	}
+
+
+	udata = ubus.call({
+		object: "service",
+		method: "get_data",
+		data: {
 			type: "wifi-iface"
 		},
 	});
 
 	for (let svcname, svc in udata) {
-		for (let typename, data in svc) {
-			for (let radio, vifs in data) {
-				for (let name, vif in vifs) {
-					let devs = vif.device;
-					if (type(devs) != "array")
-						devs = [ devs ];
-					let config = vif.config;
-					if (!config)
+		for (let insname, ins in svc) {
+			for (let typename, data in ins) {
+				for (let radio, vifs in data) {
+					if (type(vifs) != "object")
 						continue;
-					for (let device in devs) {
-						let dev = devices[device];
-						if (!dev)
-							continue;
 
-						let vif_data = {
-							name, device, config,
-							vlan: [],
-							sta: []
-						};
-						if (vif.vlans)
-							vif_data.vlans = vif.vlans;
-						if (vif.stations)
-							vif_data.sta = vif.stations;
-						vifs[name] ??= [];
-						push(vifs[name], vif_data);
-						push(dev.vif, vif_data);
+					for (let name, vif in vifs) {
+						let devs = vif.device;
+						if (type(devs) != "array")
+							devs = [ devs ];
+						let config = vif.config;
+						if (!config)
+							continue;
+						for (let device in devs) {
+							let dev = devices[device];
+							if (!dev)
+								continue;
+
+							let vif_data = {
+								name, device, config,
+								vlan: [],
+								sta: []
+							};
+							if (vif.vlans)
+								vif_data.vlans = vif.vlans;
+							if (vif.stations)
+								vif_data.sta = vif.stations;
+							vifs[name] ??= [];
+							push(vifs[name], vif_data);
+							push(dev.vif, vif_data);
+						}
 					}
 				}
 			}
@@ -241,11 +283,11 @@ function check_interfaces()
 			dev.check();
 }
 
-function hotplug(name, add)
+function hotplug(ifname, add)
 {
 	for (let name, dev in wireless.devices)
 		if (dev.autostart)
-			dev.hotplug(name, add);
+			dev.hotplug(ifname, add);
 }
 
 const network_config_attr = {

--- a/extdev.c
+++ b/extdev.c
@@ -258,7 +258,7 @@ extdev_wait_ev_cb(struct ubus_context *ctx, struct ubus_event_handler *ev_handle
 	if (strcmp(type, "ubus.object.add"))
 		return;
 
-	blobmsg_parse(&wait_policy, 1, &attr, blob_data(msg), blob_len(msg));
+	blobmsg_parse_attr(&wait_policy, 1, &attr, msg);
 	if (!attr)
 		return;
 
@@ -813,7 +813,7 @@ __bridge_reload(struct extdev_bridge *ebr, struct blob_attr *config)
 
 	if (config) {
 		config = blob_memdup(config);
-		blobmsg_parse(brpol, __BRIDGE_MAX, tb, blobmsg_data(config), blobmsg_len(config));
+		blobmsg_parse_attr(brpol, __BRIDGE_MAX, tb, config);
 		ebr->edev.dep_name = blobmsg_get_string(tb[BRIDGE_DEPENDS_ON]);
 
 		if (tb[BRIDGE_EMPTY] && blobmsg_get_bool(tb[BRIDGE_EMPTY]))
@@ -823,10 +823,8 @@ __bridge_reload(struct extdev_bridge *ebr, struct blob_attr *config)
 			config_params = ebr->edev.dev.type->config_params;
 			pol = config_params->params;
 
-			blobmsg_parse(pol, n_params, old_tb, blobmsg_data(ebr->config),
-				blobmsg_len(ebr->config));
-			blobmsg_parse(pol, n_params, brtb, blobmsg_data(config), blobmsg_len
-			(config));
+			blobmsg_parse_attr(pol, n_params, old_tb, ebr->config);
+			blobmsg_parse_attr(pol, n_params, brtb, config);
 
 			diff = 0;
 			uci_blob_diff(brtb, old_tb, config_params, &diff);
@@ -874,10 +872,8 @@ __reload(struct extdev_device *edev, struct blob_attr *config)
 	struct blob_attr *tb[params->n_params];
 	struct blob_attr *old_tb[params->n_params];
 
-	blobmsg_parse(params->params, params->n_params,	tb, blobmsg_data(config),
-		blobmsg_len(config));
-	blobmsg_parse(params->params, params->n_params,	old_tb, blobmsg_data(edev->dev.config),
-		blobmsg_len(edev->dev.config));
+	blobmsg_parse_attr(params->params, params->n_params, tb, config);
+	blobmsg_parse_attr(params->params, params->n_params, old_tb, edev->dev.config);
 
 	uci_blob_diff(tb, old_tb, edev->etype->config_params, &diff);
 	if (!diff)
@@ -1207,7 +1203,7 @@ dump_cb(struct ubus_request *req, int type, struct blob_attr *reply)
 
 	struct blob_attr *tb[n_params];
 
-	blobmsg_parse(info_policy, n_params, tb, blobmsg_data(reply), blobmsg_len(reply));
+	blobmsg_parse_attr(info_policy, n_params, tb, reply);
 	add_parsed_data(tb, info_policy, n_params, buf);
 }
 

--- a/interface-ip.c
+++ b/interface-ip.c
@@ -351,7 +351,7 @@ interface_ip_add_neighbor(struct interface *iface, struct blob_attr *attr, bool 
 	int af = v6 ? AF_INET6: AF_INET;
 	struct ether_addr *ea;
 
-	blobmsg_parse(neighbor_attr, __NEIGHBOR_MAX, tb, blobmsg_data(attr), blobmsg_data_len(attr));
+	blobmsg_parse_attr(neighbor_attr, __NEIGHBOR_MAX, tb, attr);
 
 	if (!iface) {
 		if ((cur = tb[NEIGHBOR_INTERFACE]) == NULL)
@@ -409,7 +409,7 @@ interface_ip_add_route(struct interface *iface, struct blob_attr *attr, bool v6)
 	int af = v6 ? AF_INET6 : AF_INET;
 	bool no_device = false;
 
-	blobmsg_parse(route_attr, __ROUTE_MAX, tb, blobmsg_data(attr), blobmsg_data_len(attr));
+	blobmsg_parse_attr(route_attr, __ROUTE_MAX, tb, attr);
 
 	if ((cur = tb[ROUTE_DISABLED]) != NULL && blobmsg_get_bool(cur))
 		return;

--- a/interface.c
+++ b/interface.c
@@ -704,19 +704,24 @@ interface_cleanup(struct interface *iface)
 	interface_cleanup_state(iface);
 }
 
-static void
-interface_do_free(struct interface *iface)
+void interface_free(struct interface *iface)
 {
-	interface_event(iface, IFEV_FREE);
-	interface_cleanup(iface);
 	free(iface->config);
-	netifd_ubus_remove_interface(iface);
-	avl_delete(&interfaces.avl, &iface->node.avl);
 	free(iface->zone);
 	free(iface->jail);
 	free(iface->jail_device);
 	free(iface->host_device);
 	free(iface);
+}
+
+static void
+interface_do_remove(struct interface *iface)
+{
+	interface_event(iface, IFEV_FREE);
+	interface_cleanup(iface);
+	netifd_ubus_remove_interface(iface);
+	avl_delete(&interfaces.avl, &iface->node.avl);
+	interface_free(iface);
 }
 
 static void
@@ -741,7 +746,7 @@ interface_handle_config_change(struct interface *iface)
 		interface_do_reload(iface);
 		break;
 	case IFC_REMOVE:
-		interface_do_free(iface);
+		interface_do_remove(iface);
 		return;
 	}
 	if (iface->autostart)
@@ -839,8 +844,7 @@ interface_alloc(const char *name, struct blob_attr *config, bool dynamic)
 	iface->l3_dev.cb = interface_l3_dev_cb;
 	iface->ext_dev.cb = interface_ext_dev_cb;
 
-	blobmsg_parse(iface_attrs, IFACE_ATTR_MAX, tb,
-		      blob_data(config), blob_len(config));
+	blobmsg_parse_attr(iface_attrs, IFACE_ATTR_MAX, tb, config);
 
 	iface->zone = NULL;
 	if ((cur = tb[IFACE_ATTR_ZONE]))
@@ -954,8 +958,7 @@ static bool __interface_add(struct interface *iface, struct blob_attr *config, b
 	struct blob_attr *cur;
 	char *name = NULL;
 
-	blobmsg_parse(iface_attrs, IFACE_ATTR_MAX, tb,
-		      blob_data(config), blob_len(config));
+	blobmsg_parse_attr(iface_attrs, IFACE_ATTR_MAX, tb, config);
 
 	if (alias) {
 		if ((cur = tb[IFACE_ATTR_INTERFACE]))
@@ -1274,11 +1277,8 @@ interface_device_config_changed(struct interface *if_old, struct interface *if_n
 	if (!if_new->device_config)
 		return false;
 
-	blobmsg_parse(device_attr_list.params, __DEV_ATTR_MAX, otb,
-		blob_data(if_old->config), blob_len(if_old->config));
-
-	blobmsg_parse(device_attr_list.params, __DEV_ATTR_MAX, ntb,
-		blob_data(if_new->config), blob_len(if_new->config));
+	blobmsg_parse_attr(device_attr_list.params, __DEV_ATTR_MAX, otb, if_old->config);
+	blobmsg_parse_attr(device_attr_list.params, __DEV_ATTR_MAX, ntb, if_new->config);
 
 	uci_blob_diff(ntb, otb, &device_attr_list, diff);
 
@@ -1373,6 +1373,13 @@ interface_change_config(struct interface *if_old, struct interface *if_new)
 	interface_merge_assignment_data(if_old, if_new);
 
 #undef UPDATE
+
+	if (!reload) {
+		struct device *old_dev = if_old->main_dev.dev;
+
+		interface_claim_device(if_old);
+		reload = if_old->main_dev.dev != old_dev;
+	}
 
 	if (reload) {
 		D(INTERFACE, "Reload interface '%s' because of config changes",

--- a/interface.h
+++ b/interface.h
@@ -184,6 +184,7 @@ extern struct vlist_tree interfaces;
 extern const struct uci_blob_param_list interface_attr_list;
 
 struct interface *interface_alloc(const char *name, struct blob_attr *config, bool dynamic);
+void interface_free(struct interface *iface);
 
 bool interface_add(struct interface *iface, struct blob_attr *config);
 bool interface_add_alias(struct interface *iface, struct blob_attr *config);

--- a/iprule.c
+++ b/iprule.c
@@ -211,7 +211,7 @@ iprule_add(struct blob_attr *attr, bool v6)
 	char *iface_name;
 	int af = v6 ? AF_INET6 : AF_INET;
 
-	blobmsg_parse(rule_attr, __RULE_MAX, tb, blobmsg_data(attr), blobmsg_data_len(attr));
+	blobmsg_parse_attr(rule_attr, __RULE_MAX, tb, attr);
 
 	if ((cur = tb[RULE_DISABLED]) != NULL && blobmsg_get_bool(cur))
 		return;

--- a/macvlan.c
+++ b/macvlan.c
@@ -189,10 +189,8 @@ macvlan_reload(struct device *dev, struct blob_attr *attr)
 	mvdev = container_of(dev, struct macvlan_device, dev);
 	attr = blob_memdup(attr);
 
-	blobmsg_parse(device_attr_list.params, __DEV_ATTR_MAX, tb_dev,
-		blob_data(attr), blob_len(attr));
-	blobmsg_parse(macvlan_attrs, __MACVLAN_ATTR_MAX, tb_mv,
-		blob_data(attr), blob_len(attr));
+	blobmsg_parse_attr(device_attr_list.params, __DEV_ATTR_MAX, tb_dev, attr);
+	blobmsg_parse_attr(macvlan_attrs, __MACVLAN_ATTR_MAX, tb_mv, attr);
 
 	device_init_settings(dev, tb_dev);
 	macvlan_apply_settings(mvdev, tb_mv);
@@ -202,14 +200,14 @@ macvlan_reload(struct device *dev, struct blob_attr *attr)
 		struct blob_attr *otb_dev[__DEV_ATTR_MAX];
 		struct blob_attr *otb_mv[__MACVLAN_ATTR_MAX];
 
-		blobmsg_parse(device_attr_list.params, __DEV_ATTR_MAX, otb_dev,
-			blob_data(mvdev->config_data), blob_len(mvdev->config_data));
+		blobmsg_parse_attr(device_attr_list.params, __DEV_ATTR_MAX, otb_dev,
+				   mvdev->config_data);
 
 		if (uci_blob_diff(tb_dev, otb_dev, &device_attr_list, NULL))
 		    ret = DEV_CONFIG_RESTART;
 
-		blobmsg_parse(macvlan_attrs, __MACVLAN_ATTR_MAX, otb_mv,
-			blob_data(mvdev->config_data), blob_len(mvdev->config_data));
+		blobmsg_parse_attr(macvlan_attrs, __MACVLAN_ATTR_MAX, otb_mv,
+				   mvdev->config_data);
 
 		if (uci_blob_diff(tb_mv, otb_mv, &macvlan_attr_list, NULL))
 		    ret = DEV_CONFIG_RESTART;

--- a/proto-shell.c
+++ b/proto-shell.c
@@ -785,7 +785,7 @@ proto_shell_notify(struct interface_proto_state *proto, struct blob_attr *attr)
 
 	state = container_of(proto, struct proto_shell_state, proto);
 
-	blobmsg_parse(notify_attr, __NOTIFY_LAST, tb, blob_data(attr), blob_len(attr));
+	blobmsg_parse_attr(notify_attr, __NOTIFY_LAST, tb, attr);
 	if (!tb[NOTIFY_ACTION])
 		return UBUS_STATUS_INVALID_ARGUMENT;
 
@@ -840,7 +840,7 @@ proto_shell_checkup_attach(struct proto_shell_state *state,
 		.type = BLOBMSG_TYPE_INT32
 	};
 
-	blobmsg_parse(&checkup_policy, 1, &tb, blob_data(attr), blob_len(attr));
+	blobmsg_parse_attr(&checkup_policy, 1, &tb, (struct blob_attr *)attr);
 	if (!tb) {
 		state->checkup_interval = -1;
 		state->checkup_timeout.cb = NULL;

--- a/proto.c
+++ b/proto.c
@@ -196,7 +196,7 @@ parse_address_item(struct blob_attr *attr, bool v6, bool ext)
 	if (!addr)
 		return NULL;
 
-	blobmsg_parse(proto_ip_addr, __ADDR_MAX, tb, blobmsg_data(attr), blobmsg_data_len(attr));
+	blobmsg_parse_attr(proto_ip_addr, __ADDR_MAX, tb, attr);
 
 	addr->mask = v6 ? 128 : 32;
 	if ((cur = tb[ADDR_MASK])) {
@@ -425,7 +425,7 @@ proto_apply_static_ip_settings(struct interface *iface, struct blob_attr *attr)
 	int n_v4 = 0, n_v6 = 0;
 	struct in_addr bcast = {0,}, ptp = {0,};
 
-	blobmsg_parse(proto_ip_attributes, __OPT_MAX, tb, blob_data(attr), blob_len(attr));
+	blobmsg_parse_attr(proto_ip_attributes, __OPT_MAX, tb, attr);
 
 	if ((cur = tb[OPT_NETMASK])) {
 		netmask = parse_netmask_string(blobmsg_data(cur), false);
@@ -491,7 +491,7 @@ proto_apply_ip_settings(struct interface *iface, struct blob_attr *attr, bool ex
 	struct blob_attr *cur;
 	int n_v4 = 0, n_v6 = 0;
 
-	blobmsg_parse(proto_ip_attributes, __OPT_MAX, tb, blob_data(attr), blob_len(attr));
+	blobmsg_parse_attr(proto_ip_attributes, __OPT_MAX, tb, attr);
 
 	if ((cur = tb[OPT_IPADDR]))
 		n_v4 = parse_address_list(iface, cur, false, ext);

--- a/system-dummy.c
+++ b/system-dummy.c
@@ -11,6 +11,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
+#define SYSTEM_IMPL
 #include <sys/time.h>
 #include <stdio.h>
 #include <string.h>
@@ -32,37 +33,26 @@ int system_init(void)
 
 int system_bridge_addbr(struct device *bridge, struct bridge_config *cfg)
 {
-	D(SYSTEM, "brctl addbr %s vlan_filtering=%d",
-	  bridge->ifname, cfg->vlan_filtering);
 	return 0;
 }
 
 int system_bridge_delbr(struct device *bridge)
 {
-	D(SYSTEM, "brctl delbr %s", bridge->ifname);
 	return 0;
 }
 
 int system_bridge_addif(struct device *bridge, struct device *dev)
 {
-	D(SYSTEM, "brctl addif %s %s", bridge->ifname, dev->ifname);
 	return 0;
 }
 
 int system_bridge_delif(struct device *bridge, struct device *dev)
 {
-	D(SYSTEM, "brctl delif %s %s", bridge->ifname, dev->ifname);
 	return 0;
 }
 
 int system_bridge_vlan(const char *iface, uint16_t vid, int16_t vid_end, bool add, unsigned int vflags)
 {
-	D(SYSTEM, "brctl vlan %s %s %s vid=%d vid_end=%d pvid=%d untag=%d",
-	  add ? "add" : "remove",
-	  (vflags & BRVLAN_F_SELF) ? "self" : "master",
-	  iface, vid, vid_end,
-	  !!(vflags & BRVLAN_F_PVID),
-	  !!(vflags & BRVLAN_F_UNTAGGED));
 	return 0;
 }
 

--- a/system-linux.c
+++ b/system-linux.c
@@ -17,6 +17,7 @@
  * GNU General Public License for more details.
  */
 #define _GNU_SOURCE
+#define SYSTEM_IMPL
 
 #include <sys/socket.h>
 #include <sys/ioctl.h>
@@ -3972,8 +3973,8 @@ static int system_add_ip6_tunnel(const char *name, const unsigned int link,
 		struct blob_attr *tb_data[__IPIP6_DATA_ATTR_MAX];
 		uint32_t tun_flags = IP6_TNL_F_IGN_ENCAP_LIMIT;
 
-		blobmsg_parse(ipip6_data_attr_list.params, __IPIP6_DATA_ATTR_MAX, tb_data,
-			blobmsg_data(cur), blobmsg_len(cur));
+		blobmsg_parse_attr(ipip6_data_attr_list.params, __IPIP6_DATA_ATTR_MAX,
+				   tb_data, cur);
 
 		if ((cur = tb_data[IPIP6_DATA_ENCAPLIMIT])) {
 			char *str = blobmsg_get_string(cur);
@@ -4009,8 +4010,8 @@ static int system_add_ip6_tunnel(const char *name, const unsigned int link,
 				struct in_addr ip4prefix;
 				unsigned ip4len, ip6len, ealen, offset;
 
-				blobmsg_parse(fmr_data_attr_list.params, __FMR_DATA_ATTR_MAX, tb_fmr,
-						blobmsg_data(rcur), blobmsg_len(rcur));
+				blobmsg_parse_attr(fmr_data_attr_list.params, __FMR_DATA_ATTR_MAX,
+						   tb_fmr, rcur);
 
 				if (!(tb_cur = tb_fmr[FMR_DATA_PREFIX6]) ||
 						!parse_ip_and_netmask(AF_INET6,
@@ -4139,8 +4140,8 @@ static int system_add_gre_tunnel(const char *name, const char *kind,
 	if ((cur = tb[TUNNEL_ATTR_DATA])) {
 		struct blob_attr *tb_data[__GRE_DATA_ATTR_MAX];
 
-		blobmsg_parse(gre_data_attr_list.params, __GRE_DATA_ATTR_MAX, tb_data,
-			blobmsg_data(cur), blobmsg_len(cur));
+		blobmsg_parse_attr(gre_data_attr_list.params, __GRE_DATA_ATTR_MAX,
+				   tb_data, cur);
 
 		if ((cur = tb_data[GRE_DATA_IKEY])) {
 			if ((ikey = blobmsg_get_u32(cur)))
@@ -4369,8 +4370,8 @@ static int system_add_vti_tunnel(const char *name, const char *kind,
 		struct blob_attr *tb_data[__VTI_DATA_ATTR_MAX];
 		uint32_t ikey = 0, okey = 0;
 
-		blobmsg_parse(vti_data_attr_list.params, __VTI_DATA_ATTR_MAX, tb_data,
-			blobmsg_data(cur), blobmsg_len(cur));
+		blobmsg_parse_attr(vti_data_attr_list.params, __VTI_DATA_ATTR_MAX,
+				   tb_data, cur);
 
 		if ((cur = tb_data[VTI_DATA_IKEY])) {
 			if ((ikey = blobmsg_get_u32(cur)))
@@ -4430,8 +4431,8 @@ static int system_add_xfrm_tunnel(const char *name, const char *kind,
 		struct blob_attr *tb_data[__XFRM_DATA_ATTR_MAX];
 		uint32_t if_id = 0;
 
-		blobmsg_parse(xfrm_data_attr_list.params, __XFRM_DATA_ATTR_MAX, tb_data,
-			blobmsg_data(cur), blobmsg_len(cur));
+		blobmsg_parse_attr(xfrm_data_attr_list.params, __XFRM_DATA_ATTR_MAX,
+				   tb_data, cur);
 
 		if ((cur = tb_data[XFRM_DATA_IF_ID])) {
 			if ((if_id = blobmsg_get_u32(cur)))
@@ -4477,8 +4478,8 @@ static int system_add_vxlan(const char *name, const unsigned int link, struct bl
 	int ret = 0;
 
 	if ((cur = tb[TUNNEL_ATTR_DATA]))
-		blobmsg_parse(vxlan_data_attr_list.params, __VXLAN_DATA_ATTR_MAX, tb_data,
-			blobmsg_data(cur), blobmsg_len(cur));
+		blobmsg_parse_attr(vxlan_data_attr_list.params, __VXLAN_DATA_ATTR_MAX,
+				   tb_data, cur);
 	else
 		return -EINVAL;
 
@@ -4677,8 +4678,8 @@ static int system_add_sit_tunnel(const char *name, const unsigned int link, stru
 		unsigned int mask;
 		struct ip_tunnel_6rd p6;
 
-		blobmsg_parse(sixrd_data_attr_list.params, __SIXRD_DATA_ATTR_MAX, tb_data,
-			blobmsg_data(cur), blobmsg_len(cur));
+		blobmsg_parse_attr(sixrd_data_attr_list.params, __SIXRD_DATA_ATTR_MAX,
+				   tb_data, cur);
 
 		memset(&p6, 0, sizeof(p6));
 
@@ -4812,8 +4813,7 @@ int system_add_ip_tunnel(const struct device *dev, struct blob_attr *attr)
 	struct blob_attr *cur;
 	const char *str;
 
-	blobmsg_parse(tunnel_attr_list.params, __TUNNEL_ATTR_MAX, tb,
-		blob_data(attr), blob_len(attr));
+	blobmsg_parse_attr(tunnel_attr_list.params, __TUNNEL_ATTR_MAX, tb, attr);
 
 	system_link_del(dev->ifname);
 

--- a/system-log.h
+++ b/system-log.h
@@ -1,0 +1,73 @@
+/*
+ * netifd - network interface daemon
+ * Copyright (C) 2025 Felix Fietkau <nbd@nbd.name>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+#ifndef __NETIFD_SYSTEM_LOG_H
+#define __NETIFD_SYSTEM_LOG_H
+
+
+#define system_if_up(dev) ({ \
+	struct device *_dev = dev;					\
+	D(SYSTEM, "system_if_up(%s)", _dev ? _dev->ifname : "<none>");	\
+	system_if_up(_dev);						\
+})
+
+#define system_if_down(dev) ({ \
+	struct device *_dev = dev;					\
+	D(SYSTEM, "system_if_down(%s)", _dev ? _dev->ifname : "<none>");	\
+	system_if_down(_dev);						\
+})
+
+#define system_bridge_addbr(bridge, cfg) ({ \
+	struct device *_bridge = bridge;					\
+	struct bridge_config *_cfg = cfg;					\
+	D(SYSTEM, "system_bridge_addbr(%s)", _bridge ? _bridge->ifname : "<none>");	\
+	system_bridge_addbr(_bridge, _cfg);					\
+})
+
+#define system_bridge_delbr(bridge) ({ \
+	struct device *_bridge = bridge;					\
+	D(SYSTEM, "system_bridge_delbr(%s)", _bridge ? _bridge->ifname : "<none>");	\
+	system_bridge_delbr(_bridge);						\
+})
+
+#define system_bridge_addif(bridge, dev) ({ \
+	struct device *_bridge = bridge;					\
+	struct device *_dev = dev;						\
+	D(SYSTEM, "system_bridge_addif(%s, %s)", _bridge ? _bridge->ifname : "<none>", _dev ? _dev->ifname : "<none>");	\
+	system_bridge_addif(_bridge, _dev);					\
+})
+
+#define system_bridge_delif(bridge, dev) ({ \
+	struct device *_bridge = bridge;					\
+	struct device *_dev = dev;						\
+	D(SYSTEM, "system_bridge_delif(%s, %s)", _bridge ? _bridge->ifname : "<none>", _dev ? _dev->ifname : "<none>");	\
+	system_bridge_delif(_bridge, _dev);					\
+})
+
+#define system_bridge_vlan(iface, vid, vid_end, add, vflags) ({ \
+	const char *_iface = iface;						\
+	uint16_t _vid = vid;							\
+	int16_t _vid_end = vid_end;						\
+	bool _add = add;							\
+	unsigned int _vflags = vflags;						\
+	D(SYSTEM, "system_bridge_vlan(%s, %s, %s, vid=%d, vid_end=%d, pvid=%d, untag=%d)", \
+	  _iface ? _iface : "<none>",						\
+	  _add ? "add" : "remove",						\
+	  (_vflags & BRVLAN_F_SELF) ? "self" : "master",			\
+	  _vid, _vid_end,							\
+	  !!(_vflags & BRVLAN_F_PVID),						\
+	  !!(_vflags & BRVLAN_F_UNTAGGED));					\
+	system_bridge_vlan(_iface, _vid, _vid_end, _add, _vflags);		\
+})
+
+#endif

--- a/system.c
+++ b/system.c
@@ -11,6 +11,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
+#define SYSTEM_IMPL
 #include "netifd.h"
 #include "system.h"
 #include <fcntl.h>

--- a/system.h
+++ b/system.h
@@ -334,4 +334,9 @@ int system_netns_open(const pid_t target_ns);
 int system_netns_set(int netns_fd);
 
 void system_globals_apply_settings(const struct global_settings *settings);
+
+#ifndef SYSTEM_IMPL
+#include "system-log.h"
+#endif
+
 #endif

--- a/tunnel.c
+++ b/tunnel.c
@@ -52,8 +52,7 @@ tunnel_reload(struct device *dev, struct blob_attr *attr)
 	memset(tb_dev, 0, sizeof(tb_dev));
 
 	if (attr)
-		blobmsg_parse(device_attr_list.params, __DEV_ATTR_MAX, tb_dev,
-			blob_data(attr), blob_len(attr));
+		blobmsg_parse_attr(device_attr_list.params, __DEV_ATTR_MAX, tb_dev, attr);
 
 	device_init_settings(dev, tb_dev);
 

--- a/ubus.c
+++ b/ubus.c
@@ -76,7 +76,7 @@ netifd_add_host_route(struct ubus_context *ctx, struct ubus_object *obj,
 	bool v6 = false;
 	bool exclude = false;
 
-	blobmsg_parse(route_policy, __HR_MAX, tb, blob_data(msg), blob_len(msg));
+	blobmsg_parse_attr(route_policy, __HR_MAX, tb, msg);
 	if (!tb[HR_TARGET])
 		return UBUS_STATUS_INVALID_ARGUMENT;
 
@@ -135,7 +135,7 @@ netifd_add_dynamic(struct ubus_context *ctx, struct ubus_object *obj,
 	struct interface *iface;
 	struct blob_attr *config;
 
-	blobmsg_parse(dynamic_policy, __DI_MAX, tb, blob_data(msg), blob_len(msg));
+	blobmsg_parse_attr(dynamic_policy, __DI_MAX, tb, msg);
 
 	if (!tb[DI_NAME])
 		return UBUS_STATUS_INVALID_ARGUMENT;
@@ -185,7 +185,7 @@ netifd_netns_updown(struct ubus_context *ctx, struct ubus_object *obj,
 	if (target_netns_fd < 0)
 		return UBUS_STATUS_INVALID_ARGUMENT;
 
-	blobmsg_parse(netns_updown_policy, __NETNS_UPDOWN_MAX, tb, blob_data(msg), blob_len(msg));
+	blobmsg_parse_attr(netns_updown_policy, __NETNS_UPDOWN_MAX, tb, msg);
 
 	start = tb[NETNS_UPDOWN_START] && blobmsg_get_bool(tb[NETNS_UPDOWN_START]);
 
@@ -238,7 +238,7 @@ netifd_dev_status(struct ubus_context *ctx, struct ubus_object *obj,
 	struct device *dev = NULL;
 	struct blob_attr *tb[__DEV_MAX];
 
-	blobmsg_parse(dev_policy, __DEV_MAX, tb, blob_data(msg), blob_len(msg));
+	blobmsg_parse_attr(dev_policy, __DEV_MAX, tb, msg);
 
 	if (tb[DEV_NAME]) {
 		dev = device_find(blobmsg_data(tb[DEV_NAME]));
@@ -274,7 +274,7 @@ netifd_handle_alias(struct ubus_context *ctx, struct ubus_object *obj,
 	struct blob_attr *cur;
 	size_t rem;
 
-	blobmsg_parse(alias_attrs, __ALIAS_ATTR_MAX, tb, blob_data(msg), blob_len(msg));
+	blobmsg_parse_attr(alias_attrs, __ALIAS_ATTR_MAX, tb, msg);
 
 	if (!tb[ALIAS_ATTR_ALIAS])
 		return UBUS_STATUS_INVALID_ARGUMENT;
@@ -326,7 +326,7 @@ netifd_handle_set_state(struct ubus_context *ctx, struct ubus_object *obj,
 	struct blob_attr *cur;
 	bool auth_status;
 
-	blobmsg_parse(dev_state_policy, __DEV_STATE_MAX, tb, blob_data(msg), blob_len(msg));
+	blobmsg_parse_attr(dev_state_policy, __DEV_STATE_MAX, tb, msg);
 
 	cur = tb[DEV_STATE_NAME];
 	if (!cur)
@@ -370,8 +370,7 @@ netifd_handle_dev_hotplug(struct ubus_context *ctx, struct ubus_object *obj,
 	struct blob_attr *tb[__DEV_HOTPLUG_ATTR_MAX];
 	const char *name;
 
-	blobmsg_parse(dev_hotplug_policy, __DEV_HOTPLUG_ATTR_MAX, tb,
-		      blob_data(msg), blob_len(msg));
+	blobmsg_parse_attr(dev_hotplug_policy, __DEV_HOTPLUG_ATTR_MAX, tb, msg);
 
 	if (!tb[DEV_HOTPLUG_ATTR_NAME] || !tb[DEV_HOTPLUG_ATTR_ADD])
 		return UBUS_STATUS_INVALID_ARGUMENT;
@@ -1006,7 +1005,7 @@ netifd_iface_handle_device(struct ubus_context *ctx, struct ubus_object *obj,
 
 	iface = container_of(obj, struct interface, ubus);
 
-	blobmsg_parse(dev_link_policy, __DEV_LINK_MAX, tb, blob_data(msg), blob_len(msg));
+	blobmsg_parse_attr(dev_link_policy, __DEV_LINK_MAX, tb, msg);
 
 	if (!tb[DEV_LINK_NAME])
 		return UBUS_STATUS_INVALID_ARGUMENT;
@@ -1147,7 +1146,7 @@ netifd_handle_iface(struct ubus_context *ctx, struct ubus_object *obj,
 	struct blob_attr *tb;
 	size_t i;
 
-	blobmsg_parse(&iface_policy, 1, &tb, blob_data(msg), blob_len(msg));
+	blobmsg_parse_attr(&iface_policy, 1, &tb, msg);
 	if (!tb)
 		return UBUS_STATUS_INVALID_ARGUMENT;
 
@@ -1297,8 +1296,8 @@ netifd_ubus_data_cb(struct ubus_request *req, int type, struct blob_attr *msg)
 					blobmsg_type(t) != BLOBMSG_TYPE_TABLE)
 					continue;
 				blobmsg_for_each_attr(data, t, rem4) {
-					if (!blobmsg_check_attr(t, true) ||
-						blobmsg_type(t) != BLOBMSG_TYPE_TABLE)
+					if (!blobmsg_check_attr(data, true) ||
+						blobmsg_type(data) != BLOBMSG_TYPE_TABLE)
 						continue;
 					cb(data);
 				}

--- a/ucode.c
+++ b/ucode.c
@@ -442,7 +442,7 @@ uc_netifd_process(uc_vm_t *vm, size_t nargs)
 
 	prefix_str = ucv_string_get(prefix);
 
-	res = ucv_resource_create_ex(vm, "netifd.process", (void **)&up, 1, sizeof(*up) + strlen(prefix_str + 1));
+	res = ucv_resource_create_ex(vm, "netifd.process", (void **)&up, 1, sizeof(*up) + strlen(prefix_str) + 1);
 	if (!res)
 		return NULL;
 

--- a/veth.c
+++ b/veth.c
@@ -169,10 +169,8 @@ veth_reload(struct device *dev, struct blob_attr *attr)
 	veth = container_of(dev, struct veth, dev);
 	attr = blob_memdup(attr);
 
-	blobmsg_parse(device_attr_list.params, __DEV_ATTR_MAX, tb_dev,
-		blob_data(attr), blob_len(attr));
-	blobmsg_parse(veth_attrs, __VETH_ATTR_MAX, tb_mv,
-		blob_data(attr), blob_len(attr));
+	blobmsg_parse_attr(device_attr_list.params, __DEV_ATTR_MAX, tb_dev, attr);
+	blobmsg_parse_attr(veth_attrs, __VETH_ATTR_MAX, tb_mv, attr);
 
 	device_init_settings(dev, tb_dev);
 	veth_apply_settings(veth, tb_mv);
@@ -181,14 +179,14 @@ veth_reload(struct device *dev, struct blob_attr *attr)
 		struct blob_attr *otb_dev[__DEV_ATTR_MAX];
 		struct blob_attr *otb_mv[__VETH_ATTR_MAX];
 
-		blobmsg_parse(device_attr_list.params, __DEV_ATTR_MAX, otb_dev,
-			blob_data(veth->config_data), blob_len(veth->config_data));
+		blobmsg_parse_attr(device_attr_list.params, __DEV_ATTR_MAX, otb_dev,
+				   veth->config_data);
 
 		if (uci_blob_diff(tb_dev, otb_dev, &device_attr_list, NULL))
 		    ret = DEV_CONFIG_RESTART;
 
-		blobmsg_parse(veth_attrs, __VETH_ATTR_MAX, otb_mv,
-			blob_data(veth->config_data), blob_len(veth->config_data));
+		blobmsg_parse_attr(veth_attrs, __VETH_ATTR_MAX, otb_mv,
+				   veth->config_data);
 
 		if (uci_blob_diff(tb_mv, otb_mv, &veth_attr_list, NULL))
 		    ret = DEV_CONFIG_RESTART;

--- a/vlandev.c
+++ b/vlandev.c
@@ -346,10 +346,8 @@ vlandev_reload(struct device *dev, struct blob_attr *attr)
 	mvdev = container_of(dev, struct vlandev_device, dev);
 	attr = blob_memdup(attr);
 
-	blobmsg_parse(device_attr_list.params, __DEV_ATTR_MAX, tb_dev,
-		blob_data(attr), blob_len(attr));
-	blobmsg_parse(vlandev_attrs, __VLANDEV_ATTR_MAX, tb_mv,
-		blob_data(attr), blob_len(attr));
+	blobmsg_parse_attr(device_attr_list.params, __DEV_ATTR_MAX, tb_dev, attr);
+	blobmsg_parse_attr(vlandev_attrs, __VLANDEV_ATTR_MAX, tb_mv, attr);
 
 	device_init_settings(dev, tb_dev);
 	vlandev_apply_settings(mvdev, tb_mv);
@@ -360,14 +358,14 @@ vlandev_reload(struct device *dev, struct blob_attr *attr)
 		struct blob_attr *otb_dev[__DEV_ATTR_MAX];
 		struct blob_attr *otb_mv[__VLANDEV_ATTR_MAX];
 
-		blobmsg_parse(device_attr_list.params, __DEV_ATTR_MAX, otb_dev,
-			blob_data(mvdev->config_data), blob_len(mvdev->config_data));
+		blobmsg_parse_attr(device_attr_list.params, __DEV_ATTR_MAX, otb_dev,
+				   mvdev->config_data);
 
 		if (uci_blob_diff(tb_dev, otb_dev, &device_attr_list, NULL))
 		    ret = DEV_CONFIG_RESTART;
 
-		blobmsg_parse(vlandev_attrs, __VLANDEV_ATTR_MAX, otb_mv,
-			blob_data(mvdev->config_data), blob_len(mvdev->config_data));
+		blobmsg_parse_attr(vlandev_attrs, __VLANDEV_ATTR_MAX, otb_mv,
+				   mvdev->config_data);
 
 		if (uci_blob_diff(tb_mv, otb_mv, &vlandev_attr_list, NULL))
 		    ret = DEV_CONFIG_RESTART;

--- a/vrf.c
+++ b/vrf.c
@@ -580,10 +580,8 @@ vrf_reload(struct device *dev, struct blob_attr *attr)
 	vst = container_of(dev, struct vrf_state, dev);
 	attr = blob_memdup(attr);
 
-	blobmsg_parse(device_attr_list.params, __DEV_ATTR_MAX, tb_dev,
-		blob_data(attr), blob_len(attr));
-	blobmsg_parse(vrf_attrs, __VRF_ATTR_MAX, tb_v,
-		blob_data(attr), blob_len(attr));
+	blobmsg_parse_attr(device_attr_list.params, __DEV_ATTR_MAX, tb_dev, attr);
+	blobmsg_parse_attr(vrf_attrs, __VRF_ATTR_MAX, tb_v, attr);
 
 	if (tb_dev[DEV_ATTR_MACADDR])
 		vst->primary_port = NULL;
@@ -596,8 +594,8 @@ vrf_reload(struct device *dev, struct blob_attr *attr)
 		struct blob_attr *otb_dev[__DEV_ATTR_MAX];
 		struct blob_attr *otb_v[__VRF_ATTR_MAX];
 
-		blobmsg_parse(device_attr_list.params, __DEV_ATTR_MAX, otb_dev,
-			blob_data(vst->config_data), blob_len(vst->config_data));
+		blobmsg_parse_attr(device_attr_list.params, __DEV_ATTR_MAX, otb_dev,
+				   vst->config_data);
 
 		diff[0] = diff[1] = 0;
 		uci_blob_diff(tb_dev, otb_dev, &device_attr_list, diff);
@@ -607,8 +605,8 @@ vrf_reload(struct device *dev, struct blob_attr *attr)
 			  dev->ifname, diff[1], diff[0]);
 		}
 
-		blobmsg_parse(vrf_attrs, __VRF_ATTR_MAX, otb_v,
-			blob_data(vst->config_data), blob_len(vst->config_data));
+		blobmsg_parse_attr(vrf_attrs, __VRF_ATTR_MAX, otb_v,
+				   vst->config_data);
 
 		diff[0] = diff[1] = 0;
 		uci_blob_diff(tb_v, otb_v, &vrf_attr_list, diff);


### PR DESCRIPTION
    applied changes from 3d140ec0b834e3764e8abe9d33989b76544f8ee9 to 649028013a3c8f6ed53fc97ca997d2528d06b5d9 in the upstream
    The summary is:
    - config: fix overriding bridge-vlan sections via procd data
    - system: add logging wrappers for basic system functions
    - bridge: fix reload when ports refer to aliased vlans on another bridge
    - interface: fix reload for devices that point to vlan aliases
    - netifd: fix misplaced ")"
    - bridge: fix changing the vlan local flag at runtime
    - examples: sync wireless.uc
    - config: add support for defining interfaces via procd data
    - config: add support for defining devices via procd data
    - global: use blobmsg_parse_attr
    - interface: avoid memleaks on invalid interfaces
    - ubus: fix type check in procd ubus data callback
    - examples: sync scripts with openwrt
    